### PR TITLE
REP-111 screen layout

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -8,3 +8,14 @@
 .clickme {
   cursor: pointer;
 }
+
+.forcebreak {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}

--- a/components/Business.vue
+++ b/components/Business.vue
@@ -9,6 +9,7 @@
       'mb-3': true,
       'm-0': true,
       rounded: true,
+      forcebreak: true,
     }"
   >
     <div class="business" @click="select">

--- a/components/Business.vue
+++ b/components/Business.vue
@@ -57,7 +57,7 @@
               <client-only>
                 <v-icon name="map-marker" class="icon" />
               </client-only>
-              <span>{{ business.address }}</span>
+              <span>{{ business.address }}, {{ business.city }}</span>
             </p>
           </div>
         </div>

--- a/components/BusinessList.vue
+++ b/components/BusinessList.vue
@@ -2,7 +2,7 @@
   <div>
     <Business
       v-for="business in sortedBusinesses"
-      :key="'business-' + business.uid + '-' + selected"
+      :key="'business-' + business.uid"
       :business="business"
       :selected="selected"
       @select="$emit('select', business.uid)"

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -265,7 +265,7 @@ export default {
     font-size: 2rem;
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-up(xl) {
     font-size: 2rem;
 
     h1 {
@@ -278,6 +278,10 @@ export default {
   font-size: 0.8rem;
 
   @include media-breakpoint-up(md) {
+    font-size: 1rem;
+  }
+
+  @include media-breakpoint-up(xl) {
     font-size: 1.25rem;
   }
 }
@@ -287,7 +291,11 @@ export default {
 }
 
 p {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
+
+  @include media-breakpoint-up(xl) {
+    margin-bottom: 0.5rem;
+  }
 }
 
 .badge {

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -16,7 +16,7 @@
       :title="business.name"
       @click="select"
     />
-    <b-modal v-model="show" size="md" header-class="p-0" hide-backdrop>
+    <b-modal v-model="show" size="lg" header-class="p-0" hide-backdrop>
       <template slot="modal-header" slot-scope="{ cancel }">
         <div class="large title w-100 opensans">
           <b-btn variant="link" class="float-right clickme" @click="cancel">

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -16,9 +16,15 @@
       :title="business.name"
       @click="select"
     />
-    <b-modal v-model="show" size="md" header-class="p-0" hide-backdrop>
+    <b-modal
+      v-model="show"
+      size="md"
+      header-class="p-0"
+      body-class="p-2 p-sm-4"
+      hide-backdrop
+    >
       <template slot="modal-header" slot-scope="{ cancel }">
-        <div class="large title w-100 opensans">
+        <div class="large title w-100 opensans p-2 p-sm-4">
           <b-btn variant="link" class="float-right clickme" @click="cancel">
             <v-icon name="times" class="text-white" scale="2" />
           </b-btn>
@@ -73,7 +79,7 @@
           </b-badge>
         </div>
 
-        <p v-if="website" class="mt-3">
+        <p v-if="website" class="mt-1 mt-sm-3">
           <v-icon name="globe" class="fa-fw icon" />
           <a
             target="_blank"
@@ -259,10 +265,14 @@ export default {
 }
 
 .large {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 
   h1 {
     font-size: 2rem;
+  }
+
+  @include media-breakpoint-up(sm) {
+    font-size: 1.5rem;
   }
 
   @include media-breakpoint-up(md) {
@@ -275,7 +285,11 @@ export default {
 }
 
 .category {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
+
+  @include media-breakpoint-up(sm) {
+    font-size: 0.8rem;
+  }
 
   @include media-breakpoint-up(md) {
     font-size: 1.25rem;
@@ -288,6 +302,11 @@ export default {
 
 p {
   margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+
+  @include media-breakpoint-up(sm) {
+    font-size: 1rem;
+  }
 }
 
 .badge {
@@ -315,7 +334,12 @@ a {
 }
 
 .description {
-  font-size: 14pt;
+  font-size: 1rem;
+
+  @include media-breakpoint-up(sm) {
+    font-size: 1.25rem;
+  }
+
   line-height: 1;
 }
 </style>

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -16,15 +16,9 @@
       :title="business.name"
       @click="select"
     />
-    <b-modal
-      v-model="show"
-      size="md"
-      header-class="p-0"
-      body-class="p-2 p-sm-4"
-      hide-backdrop
-    >
+    <b-modal v-model="show" size="md" header-class="p-0" hide-backdrop>
       <template slot="modal-header" slot-scope="{ cancel }">
-        <div class="large title w-100 opensans p-2 p-sm-4">
+        <div class="large title w-100 opensans">
           <b-btn variant="link" class="float-right clickme" @click="cancel">
             <v-icon name="times" class="text-white" scale="2" />
           </b-btn>
@@ -79,7 +73,7 @@
           </b-badge>
         </div>
 
-        <p v-if="website" class="mt-1 mt-sm-3">
+        <p v-if="website" class="mt-3">
           <v-icon name="globe" class="fa-fw icon" />
           <a
             target="_blank"
@@ -265,14 +259,10 @@ export default {
 }
 
 .large {
-  font-size: 1.25rem;
+  font-size: 1.5rem;
 
   h1 {
     font-size: 2rem;
-  }
-
-  @include media-breakpoint-up(sm) {
-    font-size: 1.5rem;
   }
 
   @include media-breakpoint-up(md) {
@@ -285,11 +275,7 @@ export default {
 }
 
 .category {
-  font-size: 0.75rem;
-
-  @include media-breakpoint-up(sm) {
-    font-size: 0.8rem;
-  }
+  font-size: 0.8rem;
 
   @include media-breakpoint-up(md) {
     font-size: 1.25rem;
@@ -302,11 +288,6 @@ export default {
 
 p {
   margin-bottom: 0.5rem;
-  font-size: 0.8rem;
-
-  @include media-breakpoint-up(sm) {
-    font-size: 1rem;
-  }
 }
 
 .badge {
@@ -334,12 +315,7 @@ a {
 }
 
 .description {
-  font-size: 1rem;
-
-  @include media-breakpoint-up(sm) {
-    font-size: 1.25rem;
-  }
-
+  font-size: 14pt;
   line-height: 1;
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 const proxyConfig = () => {
   // Setting the API environment variable allows you to point at a development server if required, e.g.
-  // API=https://map.restarters.dev
+  // API=https://map.restarters.dev/map
   return {
     '/api/': process.env.API
       ? process.env.API

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,6 +27,7 @@ export default {
 
   plugins: [
     { src: '~/mixins/global.js' },
+    { src: '~/plugins/axios-baseurl' },
     { src: '@/plugins/vue-google-maps', ssr: false },
     { src: '@/plugins/vue2-leaflet', ssr: false },
     { src: '@/plugins/vue-star-rating', ssr: false },
@@ -70,6 +71,12 @@ export default {
 
   // Proxy to avoid CORS restrictions on API in development environment
   proxy: proxyConfig(),
+
+  env: {
+    // This will be used on the client in axios-baseurl to send requests to the same API endpoing that the server-side
+    // code uses.
+    API: process.env.API || 'https://map.restarters.net/map/'
+  },
 
   build: {
     transpile: [/^vue2-google-maps($|\/)/],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,6 +17,8 @@ export default {
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { hid: 'description', name: 'description', content: '' },
+      { name: 'apple-mobile-web-app-title', content: 'Repair Directory' },
+      { name: 'og:site_name', content: 'Repair Directory' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,9 +11,9 @@ export default {
     // For SSR we want to have all the businesses loaded, unless we have a specific search filter.
     let category = null
 
-    // Until the server has a concept of regions, we'll just search with a big radius.
-    let location = 'London, UK'
+    // We'll just search with a big radius, which will include anything in this region.
     let radius = 2000
+    let location = null
 
     if (route.query.location) {
       location = route.query.location
@@ -27,14 +27,17 @@ export default {
       radius = route.query.radius
     }
 
+    const region = route.query.region || REGION_LONDON
+
     await store.dispatch('businesses/search', {
       category,
       location,
       radius,
+      region,
     })
 
     return {
-      region: route.query.region || REGION_LONDON,
+      region,
     }
   },
   head() {

--- a/plugins/axios-baseurl.js
+++ b/plugins/axios-baseurl.js
@@ -1,0 +1,8 @@
+/**
+ * This sets up the client to talk to the same API whether or not the code is client or server side.
+ *
+ * @param $axios
+ */
+export default function ({ $axios }) {
+  $axios.defaults.baseURL = process.env.API
+}


### PR DESCRIPTION
Most of this is tweaks to make things look better on some devices.

Two interesting things:

- The scroll into view of the business wasn't working on some slow devices.  This looks like a timing window - I could repro on Chrome when throttling the CPU.  The use of 'key' in BusinessList was re-rendering the entire list when the selected business changed.  That is a bad idea anyway, and seemed to be responsible.
- The was an issue with API requests working in the SSR code and not when searching.  I've stolen the Freegle approach of having and environment variable on the server (API) which is passed to the client via the env: section in nuxt.config, and which is then used in axios requests by setting baseUrl.  The result is that both server code and client code make requests to the same URL.  

As part of this I have disabled CORS on the dev server, and will need to do that on the live server.  My view is that CORS should not really be enabled on APIs; anyone who wants to scrape your data or abuse your API will be doing that from a script, not a browser, and therefore CORS protection wouldn't kick in anyway.