### PR TITLE
REP-113 legacy analytics

### DIFF
--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -330,9 +330,19 @@ export default {
       })
 
       this.busy = false
+
+      // Track the search.
+      this.$ga.event('search', 'submit', this.category || 'All Categories')
     },
     select(uid) {
       this.selected = uid
+
+      // Track the select.
+      const business = this.$store.getters['businesses/get'](uid)
+      const value = [business.name, business.address, business.postcode].join(
+        ', '
+      )
+      this.$ga.event('map', 'select', value)
     },
     showMoreInfo() {
       this.waitForRef('moreinfomodal', () => {


### PR DESCRIPTION
This adds the 'map' and 'search' Google Analytics events.

We may want to revisit what we track in future, but this restores the old behaviour.