### PR TITLE
REP-108 configurable domain

### DIFF
--- a/components/Business.vue
+++ b/components/Business.vue
@@ -91,17 +91,6 @@ export default {
       showShareModal: false,
     }
   },
-  computed: {
-    url() {
-      return (
-        window.location.protocol +
-        '//' +
-        window.location.hostname +
-        '/businesses/' +
-        this.business.uid
-      )
-    },
-  },
   watch: {
     selected: {
       immediate: true,

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -144,7 +144,6 @@ export default {
   },
   computed: {
     business() {
-      console.log('BusinessModal get business', this.id)
       return this.id ? this.$store.getters['businesses/get'](this.id) : null
     },
     website() {

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -56,7 +56,7 @@
             :key="category"
             size="md"
             variant="dark"
-            class="mb-2 mr-2 category"
+            class="mb-2 mr-2 category text-wrap"
             pill
           >
             {{ category }}
@@ -169,11 +169,11 @@ export default {
     url() {
       return (
         this.domain +
-        '?business=' +
+        '?rd_business=' +
         this.business.uid +
-        '&region=' +
+        '&rd_region=' +
         encodeURIComponent(this.region) +
-        '&domain=' +
+        '&rd_domain=' +
         encodeURIComponent(this.domain)
       )
     },

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -1,0 +1,298 @@
+<template>
+  <div>
+    <b-modal
+      v-if="business"
+      v-model="showModal"
+      size="lg"
+      header-class="p-0"
+      hide-backdrop
+    >
+      <template slot="modal-header" slot-scope="{ cancel }">
+        <div class="large title w-100 opensans">
+          <b-btn variant="link" class="float-right clickme" @click="cancel">
+            <v-icon name="times" class="text-white" scale="2" />
+          </b-btn>
+          <h1 class="patua m-0">{{ business.name }}</h1>
+          <p v-if="business.positiveReviewPc" class="patua">
+            <client-only>
+              <star-rating
+                v-model="business.averageScore"
+                :round-start-rating="false"
+                :show-rating="false"
+                read-only
+                active-color="#eebd01"
+                :star-size="30"
+              />
+            </client-only>
+            {{ business.positiveReviewPc }}%
+            <span class="small">positive reviews</span>
+            <a
+              v-if="business.reviewSourceUrl"
+              :href="business.reviewSourceUrl"
+              target="_blank"
+              rel="noopener"
+              class="small"
+              >(source)</a
+            >
+          </p>
+          <p v-if="business.description" class="m-0 description">
+            {{ business.description }}
+          </p>
+        </div>
+      </template>
+      <template slot="modal-footer" slot-scope="{ ok, cancel }">
+        <div class="d-flex justify-content-between w-100">
+          <b-btn variant="light" @click="cancel"> Close </b-btn>
+          <b-btn variant="link" class="share" @click="share">
+            Share business
+            <v-icon name="share" />
+          </b-btn>
+        </div>
+      </template>
+      <div class="opensans">
+        <div class="mt-1">
+          <b-badge
+            v-for="category in business.categories"
+            :key="category"
+            size="md"
+            variant="dark"
+            class="mb-2 mr-2 category"
+            pill
+          >
+            {{ category }}
+          </b-badge>
+        </div>
+
+        <p v-if="website" class="mt-3">
+          <v-icon name="globe" class="fa-fw icon" />
+          <a
+            target="_blank"
+            rel="noopener"
+            :href="website"
+            class="clickme"
+            @click="trackOutboundLink(website)"
+          >
+            {{ business.website }}
+          </a>
+        </p>
+
+        <p v-if="business.email">
+          <v-icon name="envelope" class="fa-fw icon" />
+          <a
+            :href="'mailto:' + business.email"
+            @click="trackOutboundLink(business.website)"
+            >{{ business.email }}</a
+          >
+        </p>
+
+        <p v-if="phone">
+          <v-icon name="phone" class="fa-fw icon" />
+          <a
+            :href="'tel:' + phone"
+            rel="noopener"
+            @click="trackOutboundLink('tel:' + phone)"
+          >
+            {{ phone }}
+          </a>
+        </p>
+
+        <p v-if="business.address">
+          <v-icon name="map-marker" class="fa-fw icon" />
+          <span>{{ business.address }}</span>
+        </p>
+
+        <p v-if="business.warrantyOffered">
+          <v-icon name="calendar-check" class="fa-fw icon" />
+          <span>Warranty: {{ business.warranty }}</span>
+        </p>
+
+        <p v-if="business.qualifications">
+          <v-icon name="graduation-cap" class="fa-fw icon" />
+          <span>Qualifications: {{ business.qualifications }}</span>
+        </p>
+
+        <p>
+          <v-icon name="calendar" class="fa-fw icon" />
+          <span>Last updated: {{ updated }}</span>
+        </p>
+      </div>
+    </b-modal>
+    <ShareModal
+      v-if="showShareModal"
+      ref="shareModal"
+      :name="business.name"
+      :url="url"
+    />
+  </div>
+</template>
+<script>
+import ShareModal from '@/components/ShareModal'
+export default {
+  components: { ShareModal },
+  props: {
+    id: {
+      type: Number,
+      required: false,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      showModal: true,
+      showShareModal: false,
+    }
+  },
+  computed: {
+    business() {
+      console.log('BusinessModal get business', this.id)
+      return this.id ? this.$store.getters['businesses/get'](this.id) : null
+    },
+    website() {
+      if (this.business && this.business.website) {
+        return this.business.website.indexOf('http') === 0
+          ? this.business.website
+          : 'http://' + this.business.website
+      }
+      return null
+    },
+    phone() {
+      return this.business
+        ? this.business.landline || this.business.mobile
+        : null
+    },
+    updated() {
+      return this.business && this.business.updatedAt
+        ? new Date(
+            this.business.updatedAt.date.substring(0, 10)
+          ).toLocaleDateString('en-GB')
+        : ''
+    },
+    url() {
+      return (
+        this.domain +
+        '?business=' +
+        this.business.uid +
+        '&region=' +
+        encodeURIComponent(this.region) +
+        '&domain=' +
+        encodeURIComponent(this.domain)
+      )
+    },
+    completeAddress() {
+      return this.business
+        ? [this.business.address, this.business.city, this.business.postcode]
+            .filter(Boolean)
+            .join(', ')
+        : null
+    },
+  },
+  watch: {
+    id: {
+      immediate: true,
+      handler(newVal) {
+        if (newVal) {
+          this.show()
+        } else {
+          this.hide()
+        }
+      },
+    },
+  },
+  methods: {
+    show() {
+      this.showModal = true
+    },
+    hide() {
+      this.showModal = false
+    },
+    share() {
+      this.showShareModal = true
+
+      this.waitForRef('shareModal', () => {
+        this.$refs.shareModal.show()
+      })
+    },
+  },
+}
+</script>
+<style scoped lang="scss">
+@import 'bootstrap/scss/_functions';
+@import 'bootstrap/scss/_variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+@import 'assets/css/colours.scss';
+
+.title {
+  color: #fff;
+  background-color: $colour-modal-title;
+  padding: 1rem;
+}
+
+.large {
+  font-size: 1.5rem;
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  @include media-breakpoint-up(xl) {
+    font-size: 2rem;
+
+    h1 {
+      font-size: 2.5rem;
+    }
+  }
+}
+
+.category {
+  font-size: 0.8rem;
+
+  @include media-breakpoint-up(md) {
+    font-size: 1rem;
+  }
+
+  @include media-breakpoint-up(xl) {
+    font-size: 1.25rem;
+  }
+}
+
+.title a {
+  color: $colour-link;
+}
+
+p {
+  margin-bottom: 0.25rem;
+
+  @include media-breakpoint-up(xl) {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.badge {
+  font-weight: 200;
+}
+
+.icon {
+  color: #0094a7;
+}
+
+.share {
+  color: $colour-share;
+}
+
+a {
+  color: $colour-link2;
+}
+
+.opensans {
+  font-family: 'Open Sans', sans-serif;
+}
+
+.patua {
+  font-family: 'Patua One', serif;
+}
+
+.description {
+  font-size: 14pt;
+  line-height: 1;
+}
+</style>

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -245,7 +245,7 @@ export default {
 
       return ret
     },
-    location() {
+    searchHint() {
       let ret = null
 
       switch (this.region) {
@@ -278,15 +278,18 @@ export default {
     shareUrl() {
       return (
         this.domain +
-        '?location=' +
-        encodeURIComponent(this.location) +
-        '&category=' +
-        encodeURIComponent(this.category) +
-        '&radius=' +
+        '?' +
+        (this.location
+          ? '&rd_location=' + encodeURIComponent(this.location)
+          : '') +
+        (this.category
+          ? '&rd_category=' + encodeURIComponent(this.category)
+          : '') +
+        '&rd_radius=' +
         this.radius +
-        '&region=' +
+        '&rd_region=' +
         this.region +
-        '&domain=' +
+        '&rd_domain=' +
         encodeURIComponent(this.domain)
       )
     },
@@ -296,17 +299,17 @@ export default {
       this.selected = null
     })
 
-    if (this.$route.query.location) {
-      this.location = this.$route.query.location
+    if (this.$route.query.rd_location) {
+      this.location = this.$route.query.rd_location
     }
 
-    if (this.$route.query.category) {
-      this.category = this.$route.query.category
+    if (this.$route.query.rd_category) {
+      this.category = this.$route.query.rd_category
     }
 
-    if (this.$route.query.radius) {
+    if (this.$route.query.rd_radius) {
       // Specified
-      this.radius = this.$route.query.radius
+      this.radius = this.$route.query.rd_radius
     } else {
       // Set to the maximum for this region.
       this.radius = this.radiusOptions.slice(-1)[0].value
@@ -319,9 +322,10 @@ export default {
       this.busy = true
 
       await this.$store.dispatch('businesses/search', {
-        location: this.location,
+        location: this.location + ', ' + this.searchHint,
         category: this.category,
         radius: this.radius,
+        region: this.region,
       })
 
       this.busy = false

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -131,6 +131,7 @@
       name="results"
       :url="shareUrl"
     />
+    <BusinessModal :id="selected" ref="businessModal" />
   </div>
 </template>
 <script>
@@ -146,9 +147,11 @@ import {
   SEARCH_HINT_LONDON,
   SEARCH_HINT_WALES,
 } from '@/regions'
+import BusinessModal from '@/components/BusinessModal'
+import ShareModal from '@/components/ShareModal'
 
 export default {
-  components: { BusinessList, Map },
+  components: { ShareModal, BusinessModal, BusinessList, Map },
   props: {
     id: {
       type: Number,
@@ -274,9 +277,7 @@ export default {
     },
     shareUrl() {
       return (
-        window.location.protocol +
-        '//' +
-        window.location.hostname +
+        this.domain +
         '?location=' +
         encodeURIComponent(this.location) +
         '&category=' +
@@ -284,12 +285,11 @@ export default {
         '&radius=' +
         this.radius +
         '&region=' +
-        this.region
+        this.region +
+        '&domain=' +
+        encodeURIComponent(this.domain)
       )
     },
-  },
-  created() {
-    this.selected = this.id
   },
   mounted() {
     this.$root.$on('bv::modal::hidden', (bvEvent, modalId) => {
@@ -311,6 +311,8 @@ export default {
       // Set to the maximum for this region.
       this.radius = this.radiusOptions.slice(-1)[0].value
     }
+
+    this.selected = this.id
   },
   methods: {
     async search() {

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -121,7 +121,6 @@
           :businesses="businessesInBounds"
           :center="center"
           :selected="selected"
-          :region="region"
           @selected="select"
         />
       </client-only>
@@ -143,7 +142,6 @@ import {
   BOUNDS_WALES,
   DISTANCES_LONDON,
   DISTANCES_WALES,
-  REGION_LONDON,
   REGION_WALES,
   SEARCH_HINT_LONDON,
   SEARCH_HINT_WALES,
@@ -156,11 +154,6 @@ export default {
       type: Number,
       required: false,
       default: null,
-    },
-    region: {
-      type: String,
-      required: false,
-      default: REGION_LONDON,
     },
   },
   async fetch() {

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -21,12 +21,7 @@
 <script>
 import MapBusiness from '@/components/MapBusiness'
 import { gmapApi } from 'vue2-google-maps'
-import {
-  BOUNDS_LONDON,
-  BOUNDS_WALES,
-  REGION_LONDON,
-  REGION_WALES,
-} from '@/regions'
+import { BOUNDS_LONDON, BOUNDS_WALES, REGION_WALES } from '@/regions'
 
 export default {
   components: { MapBusiness },
@@ -43,11 +38,6 @@ export default {
       type: Number,
       required: false,
       default: null,
-    },
-    region: {
-      type: String,
-      required: false,
-      default: REGION_LONDON,
     },
   },
   data() {

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -10,7 +10,6 @@
       v-for="business in businesses"
       :key="'marker-' + business.uid"
       :business="business"
-      :show-modal="showModal === business.uid"
       :selected="selected"
       :map="map"
       :region="region"
@@ -44,7 +43,6 @@ export default {
     return {
       map: null,
       fitted: false,
-      showModal: false,
       osmtile:
         'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png',
       attribution:
@@ -59,15 +57,6 @@ export default {
       immediate: true,
       handler(newVal) {
         this.fitMarkers(newVal)
-      },
-    },
-    selected: {
-      immediate: true,
-      handler(newVal) {
-        // Delay modal as this interferes with list scrolling.
-        setTimeout(() => {
-          this.showModal = newVal
-        }, 1000)
       },
     },
   },

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -1,144 +1,23 @@
 <template>
-  <div>
-    <GmapMarker
-      ref="marker"
-      :icon="
-        selected === business.uid
-          ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
-          : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
-      "
-      :position="{
-        lat: business.geolocation.latitude,
-        lng: business.geolocation.longitude,
-      }"
-      :clickable="true"
-      :draggable="false"
-      :title="business.name"
-      @click="select"
-    />
-    <b-modal v-model="show" size="lg" header-class="p-0" hide-backdrop>
-      <template slot="modal-header" slot-scope="{ cancel }">
-        <div class="large title w-100 opensans">
-          <b-btn variant="link" class="float-right clickme" @click="cancel">
-            <v-icon name="times" class="text-white" scale="2" />
-          </b-btn>
-          <h1 class="patua m-0">{{ business.name }}</h1>
-          <p v-if="business.positiveReviewPc" class="patua">
-            <client-only>
-              <star-rating
-                v-model="business.averageScore"
-                :round-start-rating="false"
-                :show-rating="false"
-                read-only
-                active-color="#eebd01"
-                :star-size="30"
-              />
-            </client-only>
-            {{ business.positiveReviewPc }}%
-            <span class="small">positive reviews</span>
-            <a
-              v-if="business.reviewSourceUrl"
-              :href="business.reviewSourceUrl"
-              target="_blank"
-              rel="noopener"
-              class="small"
-              >(source)</a
-            >
-          </p>
-          <p v-if="business.description" class="m-0 description">
-            {{ business.description }}
-          </p>
-        </div>
-      </template>
-      <template slot="modal-footer" slot-scope="{ ok, cancel }">
-        <div class="d-flex justify-content-between w-100">
-          <b-btn variant="light" @click="cancel"> Close </b-btn>
-          <b-btn variant="link" class="share" @click="share">
-            Share business
-            <v-icon name="share" />
-          </b-btn>
-        </div>
-      </template>
-      <div class="opensans">
-        <div class="mt-1">
-          <b-badge
-            v-for="category in business.categories"
-            :key="category"
-            size="md"
-            variant="dark"
-            class="mb-2 mr-2 category"
-            pill
-          >
-            {{ category }}
-          </b-badge>
-        </div>
-
-        <p v-if="website" class="mt-3">
-          <v-icon name="globe" class="fa-fw icon" />
-          <a
-            target="_blank"
-            rel="noopener"
-            :href="website"
-            @click="trackOutboundLink(business.website)"
-          >
-            {{ business.website }}
-          </a>
-        </p>
-
-        <p v-if="business.email">
-          <v-icon name="envelope" class="fa-fw icon" />
-          <a
-            :href="'mailto:' + business.email"
-            @click="trackOutboundLink(business.website)"
-            >{{ business.email }}</a
-          >
-        </p>
-
-        <p v-if="phone">
-          <v-icon name="phone" class="fa-fw icon" />
-          <a
-            :href="'tel:' + phone"
-            rel="noopener"
-            @click="trackOutboundLink('tel:' + phone)"
-          >
-            {{ phone }}
-          </a>
-        </p>
-
-        <p v-if="business.address">
-          <v-icon name="map-marker" class="fa-fw icon" />
-          <span>{{ business.address }}</span>
-        </p>
-
-        <p v-if="business.warrantyOffered">
-          <v-icon name="calendar-check" class="fa-fw icon" />
-          <span>Warranty: {{ business.warranty }}</span>
-        </p>
-
-        <p v-if="business.qualifications">
-          <v-icon name="graduation-cap" class="fa-fw icon" />
-          <span>Qualifications: {{ business.qualifications }}</span>
-        </p>
-
-        <p>
-          <v-icon name="calendar" class="fa-fw icon" />
-          <span>Last updated: {{ updated }}</span>
-        </p>
-      </div>
-    </b-modal>
-    <ShareModal
-      v-if="showShareModal"
-      ref="shareModal"
-      :name="business.name"
-      :url="url"
-    />
-  </div>
+  <GmapMarker
+    ref="marker"
+    :icon="
+      selected === business.uid
+        ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
+        : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
+    "
+    :position="{
+      lat: business.geolocation.latitude,
+      lng: business.geolocation.longitude,
+    }"
+    :clickable="true"
+    :draggable="false"
+    :title="business.name"
+    @click="select"
+  />
 </template>
 <script>
-import ShareModal from '@/components/ShareModal'
-
 export default {
-  components: { ShareModal },
   props: {
     business: {
       type: Object,
@@ -153,52 +32,6 @@ export default {
       type: Object,
       required: false,
       default: null,
-    },
-  },
-  data() {
-    return {
-      show: false,
-      showShareModal: false,
-    }
-  },
-  computed: {
-    url() {
-      return (
-        window.location.protocol +
-        '//' +
-        window.location.hostname +
-        '/businesses/' +
-        this.business.uid +
-        '&region=' +
-        this.region
-      )
-    },
-    website() {
-      if (this.business && this.business.website) {
-        return this.business.website.indexOf('http') === 0
-          ? this.business.website
-          : 'http://' + this.business.website
-      }
-      return null
-    },
-    phone() {
-      return this.business
-        ? this.business.landline || this.business.mobile
-        : null
-    },
-    completeAddress() {
-      return this.business
-        ? [this.business.address, this.business.city, this.business.postcode]
-            .filter(Boolean)
-            .join(', ')
-        : null
-    },
-    updated() {
-      return this.business && this.business.updatedAt
-        ? new Date(
-            this.business.updatedAt.date.substring(0, 10)
-          ).toLocaleDateString('en-GB')
-        : ''
     },
   },
   watch: {
@@ -225,99 +58,10 @@ export default {
   },
   methods: {
     select() {
-      this.show = true
       setTimeout(() => {
         this.$emit('select', this.business.uid)
       }, 100)
     },
-    share() {
-      this.showShareModal = true
-
-      this.waitForRef('shareModal', () => {
-        this.$refs.shareModal.show()
-      })
-    },
   },
 }
 </script>
-<style scoped lang="scss">
-@import 'bootstrap/scss/_functions';
-@import 'bootstrap/scss/_variables';
-@import 'bootstrap/scss/mixins/_breakpoints';
-@import 'assets/css/colours.scss';
-
-.title {
-  color: #fff;
-  background-color: $colour-modal-title;
-  padding: 1rem;
-}
-
-.large {
-  font-size: 1.5rem;
-
-  h1 {
-    font-size: 2rem;
-  }
-
-  @include media-breakpoint-up(xl) {
-    font-size: 2rem;
-
-    h1 {
-      font-size: 2.5rem;
-    }
-  }
-}
-
-.category {
-  font-size: 0.8rem;
-
-  @include media-breakpoint-up(md) {
-    font-size: 1rem;
-  }
-
-  @include media-breakpoint-up(xl) {
-    font-size: 1.25rem;
-  }
-}
-
-.title a {
-  color: $colour-link;
-}
-
-p {
-  margin-bottom: 0.25rem;
-
-  @include media-breakpoint-up(xl) {
-    margin-bottom: 0.5rem;
-  }
-}
-
-.badge {
-  font-weight: 200;
-}
-
-.icon {
-  color: #0094a7;
-}
-
-.share {
-  color: $colour-share;
-}
-
-a {
-  color: $colour-link2;
-}
-
-.opensans {
-  font-family: 'Open Sans', sans-serif;
-}
-
-.patua {
-  font-family: 'Patua One', serif;
-}
-
-.description {
-  font-size: 14pt;
-  line-height: 1;
-}
-</style>

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -136,7 +136,6 @@
 </template>
 <script>
 import ShareModal from '@/components/ShareModal'
-import { REGION_LONDON } from '@/regions'
 
 export default {
   components: { ShareModal },
@@ -154,11 +153,6 @@ export default {
       type: Object,
       required: false,
       default: null,
-    },
-    region: {
-      type: String,
-      required: false,
-      default: REGION_LONDON,
     },
   },
   data() {

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -1,130 +1,21 @@
 <template>
-  <GmapMarker
-    ref="marker"
-    :icon="
-      selected === business.uid
-        ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
-        : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
-    "
-    :position="{
-      lat: business.geolocation.latitude,
-      lng: business.geolocation.longitude,
-    }"
-    :clickable="true"
-    :draggable="false"
-    :title="business.name"
-    @click="select"
-  />
-    <b-modal v-model="show" size="lg" header-class="p-0" hide-backdrop>
-      <template slot="modal-header" slot-scope="{ cancel }">
-        <div class="large title w-100 opensans">
-          <b-btn variant="link" class="float-right clickme" @click="cancel">
-            <v-icon name="times" class="text-white" scale="2" />
-          </b-btn>
-          <h1 class="patua m-0">{{ business.name }}</h1>
-          <p v-if="business.positiveReviewPc" class="patua">
-            <client-only>
-              <star-rating
-                v-model="business.averageScore"
-                :round-start-rating="false"
-                :show-rating="false"
-                read-only
-                active-color="#eebd01"
-                :star-size="30"
-              />
-            </client-only>
-            {{ business.positiveReviewPc }}%
-            <span class="small">positive reviews</span>
-            <a
-              v-if="business.reviewSourceUrl"
-              :href="business.reviewSourceUrl"
-              target="_blank"
-              rel="noopener"
-              class="small"
-              >(source)</a
-            >
-          </p>
-          <p v-if="business.description" class="m-0 description">
-            {{ business.description }}
-          </p>
-        </div>
-      </template>
-      <template slot="modal-footer" slot-scope="{ ok, cancel }">
-        <div class="d-flex justify-content-between w-100">
-          <b-btn variant="light" @click="cancel"> Close </b-btn>
-          <b-btn variant="link" class="share" @click="share">
-            Share business
-            <v-icon name="share" />
-          </b-btn>
-        </div>
-      </template>
-      <div class="opensans">
-        <div class="mt-1">
-          <b-badge
-            v-for="category in business.categories"
-            :key="category"
-            size="md"
-            variant="dark"
-            class="mb-2 mr-2 category"
-            pill
-          >
-            {{ category }}
-          </b-badge>
-        </div>
-
-        <p v-if="website" class="mt-3">
-          <v-icon name="globe" class="fa-fw icon" />
-          <a
-            target="_blank"
-            rel="noopener"
-            :href="website"
-            @click="trackOutboundLink(business.website)"
-          >
-            {{ business.website }}
-          </a>
-        </p>
-
-        <p v-if="business.email">
-          <v-icon name="envelope" class="fa-fw icon" />
-          <a
-            :href="'mailto:' + business.email"
-            @click="trackOutboundLink(business.website)"
-            >{{ business.email }}</a
-          >
-        </p>
-
-        <p v-if="phone">
-          <v-icon name="phone" class="fa-fw icon" />
-          <a
-            :href="'tel:' + phone"
-            rel="noopener"
-            @click="trackOutboundLink('tel:' + phone)"
-          >
-            {{ phone }}
-          </a>
-        </p>
-
-        <p v-if="business.address">
-          <v-icon name="map-marker" class="fa-fw icon" />
-          <span>{{ business.address }}, {{ business.city }}</span>
-        </p>
-
-        <p v-if="business.warrantyOffered">
-          <v-icon name="calendar-check" class="fa-fw icon" />
-          <span>Warranty: {{ business.warranty }}</span>
-        </p>
-
-        <p v-if="business.qualifications">
-          <v-icon name="graduation-cap" class="fa-fw icon" />
-          <span>Qualifications: {{ business.qualifications }}</span>
-        </p>
-
-        <p>
-          <v-icon name="calendar" class="fa-fw icon" />
-          <span>Last updated: {{ updated }}</span>
-        </p>
-      </div>
-    </b-modal>
+  <div>
+    <GmapMarker
+      ref="marker"
+      :icon="
+        selected === business.uid
+          ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
+          : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
+      "
+      :position="{
+        lat: business.geolocation.latitude,
+        lng: business.geolocation.longitude,
+      }"
+      :clickable="true"
+      :draggable="false"
+      :title="business.name"
+      @click="select"
+    />
     <ShareModal
       v-if="showShareModal"
       ref="shareModal"
@@ -134,7 +25,10 @@
   </div>
 </template>
 <script>
+import ShareModal from '@/components/ShareModal'
+
 export default {
+  components: { ShareModal },
   props: {
     business: {
       type: Object,

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -16,19 +16,10 @@
       :title="business.name"
       @click="select"
     />
-    <ShareModal
-      v-if="showShareModal"
-      ref="shareModal"
-      :name="business.name"
-      :url="url"
-    />
   </div>
 </template>
 <script>
-import ShareModal from '@/components/ShareModal'
-
 export default {
-  components: { ShareModal },
   props: {
     business: {
       type: Object,

--- a/components/MapBusiness.vue
+++ b/components/MapBusiness.vue
@@ -1,22 +1,20 @@
 <template>
-  <div>
-    <GmapMarker
-      ref="marker"
-      :icon="
-        selected === business.uid
-          ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
-          : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
-      "
-      :position="{
-        lat: business.geolocation.latitude,
-        lng: business.geolocation.longitude,
-      }"
-      :clickable="true"
-      :draggable="false"
-      :title="business.name"
-      @click="select"
-    />
-  </div>
+  <GmapMarker
+    ref="marker"
+    :icon="
+      selected === business.uid
+        ? 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
+        : 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
+    "
+    :position="{
+      lat: business.geolocation.latitude,
+      lng: business.geolocation.longitude,
+    }"
+    :clickable="true"
+    :draggable="false"
+    :title="business.name"
+    @click="select"
+  />
 </template>
 <script>
 export default {

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -39,12 +39,12 @@ Vue.mixin({
       // This method is called by the fetch method in the page mixin, or manually if that's overriden.
       await this.$store.dispatch('config/set', {
         key: 'region',
-        value: this.$route.query.region || REGION_LONDON,
+        value: this.$route.query.rd_region || REGION_LONDON,
       })
 
       await this.$store.dispatch('config/set', {
         key: 'domain',
-        value: this.$route.query.domain || 'https://map.restarters.net',
+        value: this.$route.query.rd_domain || 'https://map.restarters.net',
       })
     },
     waitForRef(name, callback) {

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -19,6 +19,10 @@ Vue.mixin({
 
       return ret
     },
+    region() {
+      console.log('Get region', this.$store.getters['config/get']('region'))
+      return this.$store.getters['config/get']('region')
+    },
   },
   methods: {
     waitForRef(name, callback) {

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -1,6 +1,11 @@
 // Global mixin so that every component can access the logged in state and user.
 import Vue from 'vue'
-import { REGION_WALES, TAGLINE_LONDON, TAGLINE_WALES } from '@/regions'
+import {
+  REGION_LONDON,
+  REGION_WALES,
+  TAGLINE_LONDON,
+  TAGLINE_WALES,
+} from '@/regions'
 
 Vue.mixin({
   computed: {
@@ -20,11 +25,28 @@ Vue.mixin({
       return ret
     },
     region() {
-      console.log('Get region', this.$store.getters['config/get']('region'))
       return this.$store.getters['config/get']('region')
+    },
+    domain() {
+      return this.$store.getters['config/get']('domain')
     },
   },
   methods: {
+    async setConfig() {
+      // Check if we've been passed some key info in URL parameters.  If so, record that in the store so that
+      // it's accessible everywhere.
+      //
+      // This method is called by the fetch method in the page mixin, or manually if that's overriden.
+      await this.$store.dispatch('config/set', {
+        key: 'region',
+        value: this.$route.query.region || REGION_LONDON,
+      })
+
+      await this.$store.dispatch('config/set', {
+        key: 'domain',
+        value: this.$route.query.domain || 'https://map.restarters.net',
+      })
+    },
     waitForRef(name, callback) {
       // When a component is conditional using a v-if, it sometimes takes more than one tick for it to appear.  So
       // we have a bit of a timer.

--- a/mixins/page.js
+++ b/mixins/page.js
@@ -1,0 +1,7 @@
+// Mixin used on every page.
+export default {
+  fetch() {
+    // If you override fetch then you need to call this manually.
+    this.setConfig()
+  },
+}

--- a/pages/businesses/_id.vue
+++ b/pages/businesses/_id.vue
@@ -10,21 +10,17 @@ export default {
   components: { BusinessPage },
   mixins: [page],
   async fetch() {
-    console.log('Business page ')
     this.setConfig()
 
     // For SSR we want to have all the businesses loaded.  The business selected will pop up in a modal.
     //
     // Until the server has a concept of regions, we'll just search with a big radius, which will include anything in
     // this region.
-    console.log('Fetch businesses')
     await this.$store.dispatch('businesses/search', {
       location: null,
       category: null,
       radius: 2000,
     })
-
-    console.log('Fetched')
   },
   data() {
     return {

--- a/pages/businesses/_id.vue
+++ b/pages/businesses/_id.vue
@@ -4,18 +4,27 @@
 <script>
 import BusinessPage from '@/components/BusinessPage'
 import { TAGLINE_GENERIC } from '@/regions'
+import page from '@/mixins/page'
 
 export default {
   components: { BusinessPage },
-  async asyncData({ store }) {
+  mixins: [page],
+  async fetch() {
+    console.log('Business page ')
+    this.setConfig()
+
     // For SSR we want to have all the businesses loaded.  The business selected will pop up in a modal.
     //
-    // Until the server has a concept of regions, we'll just search with a big radius.
-    await store.dispatch('businesses/search', {
-      location: 'London, UK',
+    // Until the server has a concept of regions, we'll just search with a big radius, which will include anything in
+    // this region.
+    console.log('Fetch businesses')
+    await this.$store.dispatch('businesses/search', {
+      location: null,
       category: null,
       radius: 2000,
     })
+
+    console.log('Fetched')
   },
   data() {
     return {
@@ -26,9 +35,6 @@ export default {
     business() {
       return this.id ? this.$store.getters['businesses/get'](this.id) : null
     },
-  },
-  created() {
-    this.id = parseInt(this.$route.params.id)
   },
   head() {
     if (this.business) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,6 @@ export default {
     this.id = this.$route.query.business
       ? parseInt(this.$route.query.business)
       : null
-    console.log('Index page, business', this.id)
 
     // For SSR we want to have all the businesses loaded, unless we have a specific search filter.
     let category = null

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,13 +1,23 @@
 <template>
-  <BusinessPage />
+  <BusinessPage :id="id" />
 </template>
 <script>
 import BusinessPage from '@/components/BusinessPage'
-import { REGION_LONDON } from '@/regions'
+import page from '@/mixins/page'
 
 export default {
   components: { BusinessPage },
-  async asyncData({ route, store }) {
+  mixins: [page],
+  async fetch() {
+    this.setConfig()
+
+    // We have been asked to show a business page.  This is passed via a query parameter so that we can do this
+    // when embedded.  The url is created inside MapBusiness.
+    this.id = this.$route.query.business
+      ? parseInt(this.$route.query.business)
+      : null
+    console.log('Index page, business', this.id)
+
     // For SSR we want to have all the businesses loaded, unless we have a specific search filter.
     let category = null
 
@@ -15,30 +25,29 @@ export default {
     let radius = 2000
     let location = null
 
-    if (route.query.location) {
-      location = route.query.location
+    if (this.$route.query.location) {
+      location = this.$route.query.location
     }
 
-    if (route.query.category) {
-      category = route.query.category
+    if (this.$route.query.category) {
+      category = this.$route.query.category
     }
 
-    if (route.query.radius) {
-      radius = route.query.radius
+    if (this.$route.query.radius) {
+      radius = this.$route.query.radius
     }
 
-    const region = route.query.region || REGION_LONDON
-
-    await store.dispatch('config/set', {
-      key: 'region',
-      value: region,
-    })
-
-    await store.dispatch('businesses/search', {
+    await this.$store.dispatch('businesses/search', {
       category,
       location,
       radius,
+      region: this.region,
     })
+  },
+  data() {
+    return {
+      id: null,
+    }
   },
   head() {
     return this.buildHead('Repair Directory', this.tagline)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <BusinessPage :region="region" />
+  <BusinessPage />
 </template>
 <script>
 import BusinessPage from '@/components/BusinessPage'
@@ -29,16 +29,16 @@ export default {
 
     const region = route.query.region || REGION_LONDON
 
+    await store.dispatch('config/set', {
+      key: 'region',
+      value: region,
+    })
+
     await store.dispatch('businesses/search', {
       category,
       location,
       radius,
-      region,
     })
-
-    return {
-      region,
-    }
   },
   head() {
     return this.buildHead('Repair Directory', this.tagline)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,8 +13,8 @@ export default {
 
     // We have been asked to show a business page.  This is passed via a query parameter so that we can do this
     // when embedded.  The url is created inside MapBusiness.
-    this.id = this.$route.query.business
-      ? parseInt(this.$route.query.business)
+    this.id = this.$route.query.rd_business
+      ? parseInt(this.$route.query.rd_business)
       : null
 
     // For SSR we want to have all the businesses loaded, unless we have a specific search filter.
@@ -24,16 +24,16 @@ export default {
     let radius = 2000
     let location = null
 
-    if (this.$route.query.location) {
-      location = this.$route.query.location
+    if (this.$route.query.rd_location) {
+      location = this.$route.query.rd_location
     }
 
-    if (this.$route.query.category) {
-      category = this.$route.query.category
+    if (this.$route.query.rd_category) {
+      category = this.$route.query.rd_category
     }
 
-    if (this.$route.query.radius) {
-      radius = this.$route.query.radius
+    if (this.$route.query.rd_radius) {
+      radius = this.$route.query.rd_radius
     }
 
     await this.$store.dispatch('businesses/search', {

--- a/store/businesses.js
+++ b/store/businesses.js
@@ -21,7 +21,6 @@ export const mutations = {
 export const getters = {
   get: (state) => (id) => {
     id = parseInt(id)
-    console.log('Get business', id, state.list[id], state.list)
     return state.list[id] ? state.list[id] : null
   },
   list: (state) => Object.values(state.list),

--- a/store/businesses.js
+++ b/store/businesses.js
@@ -21,6 +21,7 @@ export const mutations = {
 export const getters = {
   get: (state) => (id) => {
     id = parseInt(id)
+    console.log('Get business', id, state.list[id], state.list)
     return state.list[id] ? state.list[id] : null
   },
   list: (state) => Object.values(state.list),

--- a/store/categories.js
+++ b/store/categories.js
@@ -14,9 +14,11 @@ export const getters = {
 
 export const actions = {
   async list({ commit }, params) {
-    const ret = await this.$axios.get(
-      '/api/category/list?region=' + encodeURIComponent(params.region)
-    )
+    const ret = await this.$axios.get('/api/category/list', {
+      params: {
+        region: params.region || null,
+      },
+    })
 
     if (ret && ret.data && ret.data.categories) {
       commit('setList', ret.data.categories)

--- a/store/config.js
+++ b/store/config.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+
+export const state = () => ({})
+
+export const mutations = {
+  set(state, params) {
+    Vue.set(state, params.key, params.value)
+  },
+}
+
+export const getters = {
+  get: (state) => (key) => state[key],
+}
+
+export const actions = {
+  set({ commit }, params) {
+    commit('set', params)
+  },
+}


### PR DESCRIPTION
This is quite the beast.

- Introduce a "config" store.
- Move away from asyncData, which is semi-deprecated, towards fetch(), which is nicer in several ways.
- Put the region into the config store on page load.  This is then accessible more easily rather than passing it around.
- Similarly put a domain parameter into the config store.  This defaults to map.restarters.net but can be sets in the URL as a query parameter.  This will be used by the WordPress plugin.
- Include that domain in URLs we share.
- Move the modal for a business into a separate component, rather than having it included within the map marker component.
- Change all the query parameters we use to have _rd__ as a prefix.

The upshot is that things ought to behave the same unless the domain URL param is included, but it could all do with a bit of a test.