### PR TITLE
REP-129 no results

### DIFF
--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -121,6 +121,7 @@
           :businesses="businessesInBounds"
           :center="center"
           :selected="selected"
+          :location="location"
           @selected="select"
         />
       </client-only>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -55,6 +55,7 @@ export default {
       attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>',
       bounds: null,
+      lastBusinessesFitted: null,
     }
   },
   computed: {
@@ -70,23 +71,40 @@ export default {
   },
   methods: {
     idle() {
-      this.fitMarkers(this.businesses)
+      console.log('Idle, fit markers')
+
+      // We only want to fit the map to the markers if the businesses have changed since last time we did this.
+      if (
+        !this.lastBusinessesFitted ||
+        JSON.stringify(this.businesses) !== this.lastBusinessesFitted
+      ) {
+        this.lastBusinessesFitted = JSON.stringify(this.businesses)
+        this.fitMarkers(this.businesses)
+      } else {
+        console.log('No change to businesses')
+      }
     },
     select(business) {
       this.$emit('selected', business.uid)
     },
     fitMarkers(businesses) {
+      console.log('fitMarkers')
       if (this.$refs.map) {
+        console.log('Got ref')
         this.map = this.$refs.map
 
         this.$refs.map.$mapPromise.then((map) => {
+          console.log('Got promise')
           if (!businesses.length) {
             // Nothing to show.
+            console.log('Nothing to show')
             if (this.location) {
               // ...but zoom to the location to at least indicate that we searched.
+              console.log('Got location')
               this.zoom = 14
             } else {
               // ...and no location specified - show the whole region.
+              console.log('No location')
               let bounds = null
 
               switch (this.region) {
@@ -112,6 +130,7 @@ export default {
             }
           } else {
             // Got some businesses.
+            console.log('Got some businesses')
             const bounds = new this.google.maps.LatLngBounds()
 
             if (this.location && this.center) {
@@ -137,6 +156,7 @@ export default {
 
             if (businesses.length === 1) {
               // Ensure we're not too zoomed in - set a decent zoom and centre.
+              console.log('...only 1')
               this.$store.dispatch('businesses/setCenter', {
                 lat: businesses[0].geolocation.latitude,
                 lng: businesses[0].geolocation.longitude,
@@ -145,6 +165,7 @@ export default {
               this.zoom = 14
             } else {
               // Pad the map so the markers will show if they're at the edge.
+              console.log('...multiple', bounds.toString())
               map.fitBounds(bounds, {
                 padding: [30, 30],
               })

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -116,7 +116,6 @@ export default {
 
             if (this.location && this.center) {
               // Ensure we show the location we searched on.
-              console.log('Extend to center', this.center)
               bounds.extend(
                 new this.google.maps.LatLng({
                   lat: this.center[0],
@@ -127,7 +126,6 @@ export default {
 
             // Ensure we show all the businesses.
             businesses.forEach((b) => {
-              console.log('EXtend to business', b)
               bounds.extend(
                 // eslint-disable-next-line new-cap
                 new this.google.maps.LatLng(
@@ -150,7 +148,6 @@ export default {
               map.fitBounds(bounds, {
                 padding: [30, 30],
               })
-              console.log('Fitter', bounds)
             }
           }
         })

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -91,36 +91,34 @@ export default {
           }
         }
 
-        if (!businesses.length) {
-          bounds = new this.google.maps.LatLngBounds(
-            new this.google.maps.LatLng(bounds.sw),
-            new this.google.maps.LatLng(bounds.ne)
-          )
-        } else {
-          bounds = new this.google.maps.LatLngBounds()
-
-          businesses.forEach((b) => {
-            bounds.extend(
-              // eslint-disable-next-line new-cap
-              new this.google.maps.LatLng(
-                b.geolocation.latitude,
-                b.geolocation.longitude
-              )
-            )
-          })
-        }
-
         this.$refs.map.$mapPromise.then((map) => {
-          if (businesses.length === 1) {
-            // Ensure we're not too zoomed in - set a decent zoom and centre.
-            this.$store.dispatch('businesses/setCenter', {
-              lat: businesses[0].geolocation.latitude,
-              lng: businesses[0].geolocation.longitude,
-            })
-
+          if (!businesses.length) {
+            // Nothing to show, but zoom to the location to at least indicate that we searched.
             this.zoom = 14
           } else {
-            map.fitBounds(bounds)
+            bounds = new this.google.maps.LatLngBounds()
+
+            businesses.forEach((b) => {
+              bounds.extend(
+                // eslint-disable-next-line new-cap
+                new this.google.maps.LatLng(
+                  b.geolocation.latitude,
+                  b.geolocation.longitude
+                )
+              )
+            })
+
+            if (businesses.length === 1) {
+              // Ensure we're not too zoomed in - set a decent zoom and centre.
+              this.$store.dispatch('businesses/setCenter', {
+                lat: businesses[0].geolocation.latitude,
+                lng: businesses[0].geolocation.longitude,
+              })
+
+              this.zoom = 14
+            } else {
+              map.fitBounds(bounds)
+            }
           }
         })
       }

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -48,13 +48,13 @@ export default {
   data() {
     return {
       map: null,
-      fitted: false,
       zoom: null,
       showModal: false,
       osmtile:
         'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png',
       attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>',
+      bounds: null,
     }
   },
   computed: {
@@ -70,10 +70,7 @@ export default {
   },
   methods: {
     idle() {
-      if (!this.fitted) {
-        this.fitMarkers(this.businesses)
-        this.fitted = true
-      }
+      this.fitMarkers(this.businesses)
     },
     select(business) {
       this.$emit('selected', business.uid)
@@ -119,6 +116,7 @@ export default {
 
             if (this.location && this.center) {
               // Ensure we show the location we searched on.
+              console.log('Extend to center', this.center)
               bounds.extend(
                 new this.google.maps.LatLng({
                   lat: this.center[0],
@@ -129,6 +127,7 @@ export default {
 
             // Ensure we show all the businesses.
             businesses.forEach((b) => {
+              console.log('EXtend to business', b)
               bounds.extend(
                 // eslint-disable-next-line new-cap
                 new this.google.maps.LatLng(
@@ -147,7 +146,11 @@ export default {
 
               this.zoom = 14
             } else {
-              map.fitBounds(bounds)
+              // Pad the map so the markers will show if they're at the edge.
+              map.fitBounds(bounds, {
+                padding: [30, 30],
+              })
+              console.log('Fitter', bounds)
             }
           }
         })


### PR DESCRIPTION
Various changes to the way the map works.

- If we search with a location and find no results, still zoom to the place to show that at least we tried.
- If we search without a location and find no results, make sure we show the whole region.
- If we search with a location and find results, make the map cover both the location itself and the results we found.

This changes when we decide to move the map so that it is controlled by whether we have a different set of businesses, rather than a flag which was getting out of step.