### PR TITLE
REP-80 proof of concept translation

### DIFF
--- a/components/Business.vue
+++ b/components/Business.vue
@@ -24,7 +24,7 @@
           <h2 class="percentage font-weight-bold">
             {{ business.positiveReviewPc }}%
           </h2>
-          <span>positive reviews</span>
+          <span>{{ $t('positiveReviews') }}</span>
         </div>
       </div>
       <div class="business__details">

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -174,6 +174,8 @@ export default {
             this.business.uid +
             '&rd_region=' +
             encodeURIComponent(this.region) +
+            '&rd_language=' +
+            encodeURIComponent(this.language) +
             '&rd_parenturl=' +
             encodeURIComponent(this.domain)
         : null

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -26,7 +26,7 @@
               />
             </client-only>
             {{ business.positiveReviewPc }}%
-            <span class="small">positive reviews</span>
+            <span class="small">{{ $t('positiveReviews') }}</span>
             <a
               v-if="business.reviewSourceUrl"
               :href="business.reviewSourceUrl"

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -223,6 +223,7 @@ export default {
 
       if (this.categories) {
         this.categories.forEach((c) => {
+          // We want to translate the category text.
           ret.push({
             value: c,
             text: this.$t(c),

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -27,7 +27,7 @@
         </p>
         <div class="formlayout">
           <div class="left">
-            <label for="location">Where are you looking?</label>
+            <label for="location">{{ $t('whereAreYouLooking') }}</label>
             <b-input
               id="location"
               v-model="location"
@@ -101,7 +101,7 @@
             variant="link"
             @click="share"
           >
-            Share results
+            {{ $t('shareResults') }}
             <client-only>
               <v-icon name="share" />
             </client-only>
@@ -225,7 +225,7 @@ export default {
         this.categories.forEach((c) => {
           ret.push({
             value: c,
-            text: c,
+            text: this.$t(c),
           })
         })
       }

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -293,6 +293,8 @@ export default {
         this.radius +
         '&rd_region=' +
         this.region +
+        '&rd_language=' +
+        encodeURIComponent(this.language) +
         '&rd_parenturl=' +
         encodeURIComponent(this.domain)
       )

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -1,0 +1,9 @@
+export default {
+  shareResults: 'Rhannu canlyniadau',
+  whereAreYouLooking: 'Ble ydych chi’n edrych?',
+  positiveReviews: 'adolygiadau cadarnhaol',
+
+  // Categories are returned from the server.  If translations appear here, they will be used, otherwise
+  // the server text will be used instead.
+  'Bicycle / bike / cycle': 'Beiciau',
+}

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,0 +1,5 @@
+export default {
+  shareResults: 'Share results',
+  whereAreYouLooking: 'Where are you looking?',
+  positiveReviews: 'positive reviews',
+}

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -30,6 +30,9 @@ Vue.mixin({
     domain() {
       return this.$store.getters['config/get']('domain')
     },
+    language() {
+      return this.$store.getters['config/get']('language')
+    },
   },
   methods: {
     async setConfig() {
@@ -51,6 +54,11 @@ Vue.mixin({
         // Set the requested language.
         await this.$i18n.setLocale(this.$route.query.rd_language)
       }
+
+      await this.$store.dispatch('config/set', {
+        key: 'language',
+        value: this.$route.query.rd_language || null,
+      })
     },
     waitForRef(name, callback) {
       // When a component is conditional using a v-if, it sometimes takes more than one tick for it to appear.  So

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -46,6 +46,11 @@ Vue.mixin({
         key: 'domain',
         value: this.$route.query.rd_parenturl || 'https://map.restarters.net',
       })
+
+      if (this.$route.query.rd_language) {
+        // Set the requested language.
+        await this.$i18n.setLocale(this.$route.query.rd_language)
+      }
     },
     waitForRef(name, callback) {
       // When a component is conditional using a v-if, it sometimes takes more than one tick for it to appear.  So

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,7 +48,52 @@ export default {
     '@nuxtjs/axios',
     '@nuxtjs/pwa',
     'vue-scrollto/nuxt',
+    'nuxt-i18n',
   ],
+
+  i18n: {
+    locales: ['en', 'cy'],
+    defaultLocale: 'en',
+    fallbackLocale: 'en',
+
+    // We are not translating the URLs themselves, e.g. '/business'
+    strategy: 'no_prefix',
+
+    // We don't want to guess at the language - it's passed in to us via a parameter.
+    detectBrowserLanguage: false,
+
+    // Recommended for SEO.
+    onlyOnRoot: true,
+
+    vuex: {
+      // When doing SSR, the language will be set from an URL parameter.  We want to sync the locale with the i18n
+      // store so that when the client initialises, it picks up the locale.
+      syncLocale: true,
+    },
+
+    beforeLanguageSwitch: function(oldLocale, newLocale) {
+      console.log("Language switch", oldLocale, newLocale)
+    },
+
+    vueI18n: {
+      messages: {
+        en: {
+          shareResults: 'Share results',
+          whereAreYouLooking: 'Where are you looking?',
+          positiveReviews: 'positive reviews',
+        },
+        cy: {
+          shareResults: 'Rhannu canlyniadau',
+          whereAreYouLooking: 'Ble ydych chi’n edrych?',
+          positiveReviews: 'adolygiadau cadarnhaol',
+
+          // Categories are returned from the server.  If translations appear here, they will be used, otherwise
+          // the server text will be used instead.
+          'Bicycle / bike / cycle': 'Beiciau',
+        },
+      },
+    },
+  },
 
   axios: {
     proxy: true,
@@ -75,7 +120,7 @@ export default {
   env: {
     // This will be used on the client in axios-baseurl to send requests to the same API endpoing that the server-side
     // code uses.
-    API: process.env.API || 'https://map.restarters.net/map/'
+    API: process.env.API || 'https://map.restarters.net/map/',
   },
 
   build: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -52,7 +52,6 @@ export default {
   ],
 
   i18n: {
-    locales: ['en', 'cy'],
     defaultLocale: 'en',
     fallbackLocale: 'en',
 
@@ -65,33 +64,24 @@ export default {
     // Recommended for SEO.
     onlyOnRoot: true,
 
+    // Lazy load translations from files in lang folder.
+    lazy: true,
+    langDir: 'lang/',
+    locales: [
+      {
+        code: 'en',
+        file: 'en.js',
+      },
+      {
+        code: 'cy',
+        file: 'cy.js',
+      },
+    ],
+
     vuex: {
       // When doing SSR, the language will be set from an URL parameter.  We want to sync the locale with the i18n
-      // store so that when the client initialises, it picks up the locale.
+      // store so that when the client initialises, it picks up the locale used on the server to generate the page.
       syncLocale: true,
-    },
-
-    beforeLanguageSwitch: function(oldLocale, newLocale) {
-      console.log("Language switch", oldLocale, newLocale)
-    },
-
-    vueI18n: {
-      messages: {
-        en: {
-          shareResults: 'Share results',
-          whereAreYouLooking: 'Where are you looking?',
-          positiveReviews: 'positive reviews',
-        },
-        cy: {
-          shareResults: 'Rhannu canlyniadau',
-          whereAreYouLooking: 'Ble ydych chi’n edrych?',
-          positiveReviews: 'adolygiadau cadarnhaol',
-
-          // Categories are returned from the server.  If translations appear here, they will be used, otherwise
-          // the server text will be used instead.
-          'Bicycle / bike / cycle': 'Beiciau',
-        },
-      },
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,6 +1107,29 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
       "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w=="
     },
+    "@intlify/shared": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.0.0.tgz",
+      "integrity": "sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ=="
+    },
+    "@intlify/vue-i18n-extensions": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-1.0.2.tgz",
+      "integrity": "sha512-rnfA0ScyBXyp9xsSD4EAMGeOh1yv/AE7fhqdAdSOr5X8N39azz257umfRtzNT9sHXAKSSzpCVhIbMAkp5c/gjQ==",
+      "requires": {
+        "@babel/parser": "^7.9.6"
+      }
+    },
+    "@intlify/vue-i18n-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-loader/-/vue-i18n-loader-1.1.0.tgz",
+      "integrity": "sha512-9LXiztMtYKTE8t/hRwwGUp+ofrwU0sxLQLzFEOZ38zvn0DonUIQmZUj1cfz5p1Lu8BllxKbCrn6HnsRJ+LYA6g==",
+      "requires": {
+        "@intlify/shared": "^9.0.0",
+        "js-yaml": "^3.13.1",
+        "json5": "^2.1.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -6985,6 +7008,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-https": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-https/-/is-https-3.0.2.tgz",
+      "integrity": "sha512-jFgAKhbNF7J+lTMJxbq5z9bf1V9f8rXn9mP5RSY2GUEW5M0nOiVhVC9dNra96hQDjGpNzskIzusUnXwngqmhAA=="
+    },
     "is-nan": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -7128,6 +7156,11 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-0.1.15.tgz",
       "integrity": "sha512-H2xOyAnmrHcl1KaJ5fDvcKgXbps852FSTMp9v0F5nBpX0NET1xgkLFUFHNHs4i83u4ZSBXLB0qDwvrV8/lOAdw=="
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8070,6 +8103,22 @@
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.12",
         "@fortawesome/vue-fontawesome": "^0.1.4"
+      }
+    },
+    "nuxt-i18n": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/nuxt-i18n/-/nuxt-i18n-6.21.1.tgz",
+      "integrity": "sha512-zjqqUMJgIDDxrJDO5Ot3s8F1y71A4otTyGyf/RmQHptfY1HpvqwFx8087p5vUOI9XoRsGHSYB4n4wcMxurw+qA==",
+      "requires": {
+        "@babel/parser": "^7.5.5",
+        "@babel/traverse": "^7.5.5",
+        "@intlify/vue-i18n-extensions": "^1.0.1",
+        "@intlify/vue-i18n-loader": "^1.0.0",
+        "cookie": "^0.4.0",
+        "is-https": "^3.0.0",
+        "js-cookie": "^2.2.1",
+        "klona": "^2.0.4",
+        "vue-i18n": "^8.23.0"
       }
     },
     "object-assign": {
@@ -11720,6 +11769,11 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
+    },
+    "vue-i18n": {
+      "version": "8.24.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.24.2.tgz",
+      "integrity": "sha512-+TkAPBQw4Cp2bQrSPtPNkhET7XcWYjjDt1UjWYQs+xbT41q5OAl1I3IZyhg0drjn1nlC1K0f8sLVB/nshUcF1Q=="
     },
     "vue-loader": {
       "version": "15.9.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "leaflet": "^1.7.1",
     "nuxt": "^2.14.6",
     "nuxt-fontawesome": "^0.4.0",
+    "nuxt-i18n": "^6.21.1",
     "sass": "^1.29.0",
     "sass-loader": "^10.1.0",
     "scss": "^0.2.4",


### PR DESCRIPTION
This introduces proof of concept translation using nuxt-i18n.

The translations themselves are inside /lang.  Just a few initially to demonstrate the function.

The preferred language is passed via an URL parameter, `rd_language`.  This is preserved on share.

You can test this with:
* http://localhost:3000/?rd_language=en&rd_region=Wales
* http://localhost:3000/?rd_language=cy&rd_region=Wales