### PR TITLE
REP-142 submit business

### DIFF
--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -66,9 +66,7 @@
       </div>
       <div v-if="addbusiness" class="text-center bg-white p-2 font-weight-bold">
         Help us grow!
-        <a v-if="addbusiness" :href="addbusiness" target="_blank">
-          Submit a business
-        </a>
+        <a :href="addbusiness" target="_blank"> Submit a business </a>
       </div>
       <div class="business-list-container pl-md-2 pr-md-2 d-flex flex-wrap">
         <div

--- a/components/BusinessPage.vue
+++ b/components/BusinessPage.vue
@@ -64,12 +64,9 @@
           </div>
         </div>
       </div>
-      <div v-if="showSubmit" class="text-center bg-white p-2 font-weight-bold">
+      <div v-if="addbusiness" class="text-center bg-white p-2 font-weight-bold">
         Help us grow!
-        <a
-          href="https://therestartproject.org/suggest-a-business-for-the-repair-directory/"
-          target="_blank"
-        >
+        <a v-if="addbusiness" :href="addbusiness" target="_blank">
           Submit a business
         </a>
       </div>
@@ -147,7 +144,6 @@ import {
   REGION_WALES,
   SEARCH_HINT_LONDON,
   SEARCH_HINT_WALES,
-  showSubmitBusiness,
 } from '@/regions'
 import BusinessModal from '@/components/BusinessModal'
 import ShareModal from '@/components/ShareModal'
@@ -299,8 +295,8 @@ export default {
         encodeURIComponent(this.domain)
       )
     },
-    showSubmit() {
-      return showSubmitBusiness(this.region)
+    addbusiness() {
+      return this.$store.getters['config/get']('addbusiness')
     },
   },
   mounted() {

--- a/mixins/global.js
+++ b/mixins/global.js
@@ -59,6 +59,11 @@ Vue.mixin({
         key: 'language',
         value: this.$route.query.rd_language || null,
       })
+
+      await this.$store.dispatch('config/set', {
+        key: 'addbusiness',
+        value: this.$route.query.rd_addbusiness || null,
+      })
     },
     waitForRef(name, callback) {
       // When a component is conditional using a v-if, it sometimes takes more than one tick for it to appear.  So

--- a/regions.js
+++ b/regions.js
@@ -87,7 +87,3 @@ export const DISTANCES_WALES = [
     text: 'All Wales',
   },
 ]
-
-export function showSubmitBusiness(region) {
-  return region === REGION_LONDON
-}


### PR DESCRIPTION
(Sorry, the branch name is wrong)

This uses the rd_addbusiness URL parameter to control whether/what is shown for the "Submit a business" link.

We will need to change the embed on TRP and NLWA to add in this value.  I think it's better to default to it being absent rather than hardcode, but let me know if you prefer it to default to the existing link.

