### PR TITLE
REP-137 schema org

### DIFF
--- a/components/Business.vue
+++ b/components/Business.vue
@@ -12,6 +12,10 @@
       forcebreak: true,
     }"
   >
+    <BusinessSchema
+      v-if="!selected || selected === business.uid"
+      :id="business.uid"
+    />
     <div class="business" @click="select">
       <div ref="heading" class="business__heading">
         <h2 class="name rd-business-heading-color rd-primary-font">
@@ -77,9 +81,11 @@
   </div>
 </template>
 <script>
+import BusinessSchema from '@/components/BusinessSchema'
 const VueScrollTo = require('vue-scrollto')
 
 export default {
+  components: { BusinessSchema },
   props: {
     business: {
       type: Object,

--- a/components/BusinessModal.vue
+++ b/components/BusinessModal.vue
@@ -130,6 +130,7 @@
 </template>
 <script>
 import ShareModal from '@/components/ShareModal'
+
 export default {
   components: { ShareModal },
   props: {

--- a/components/BusinessSchema.vue
+++ b/components/BusinessSchema.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    v-if="business"
+    itemscope
+    itemtype="http://schema.org/Store"
+    class="d-none"
+  >
+    <div itemprop="name">{{ business.name }}</div>
+    <address
+      v-if="business.address"
+      itemprop="address"
+      itemscope
+      itemtype="https://schema.org/PostalAddress"
+    >
+      <span itemprop="streetAddress">{{ business.address }}</span>
+      <span itemprop="addressLocality">{{ business.city }}</span>
+    </address>
+    <div itemprop="geo" itemscope itemtype="https://schema.org/GeoCoordinates">
+      <meta itemprop="latitude" :content="business.geolocation.latitude" />
+      <meta itemprop="longitude" :content="business.geolocation.longitude" />
+    </div>
+    <meta itemprop="latitude" :content="business.geolocation.latitude" />
+    <meta itemprop="longitude" :content="business.geolocation.longitude" />
+    <div v-if="business.landline" itemprop="telephone">
+      {{ business.landline }}
+    </div>
+    <a v-if="business.website" :href="business.website" itemprop="url">{{
+      business.website
+    }}</a>
+    <div
+      itemprop="aggregateRating"
+      itemscope
+      itemtype="https://schema.org/AggregateRating"
+    >
+      <span itemprop="ratingValue">{{ business.averageScore }}</span>
+      <span itemprop="reviewCount">{{ business.numberOfReviews }}</span>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    id: {
+      type: Number,
+      required: false,
+      default: null,
+    },
+  },
+  data() {
+    return {}
+  },
+  computed: {
+    business() {
+      return this.id ? this.$store.getters['businesses/get'](this.id) : null
+    },
+  },
+}
+</script>

--- a/components/BusinessSchema.vue
+++ b/components/BusinessSchema.vue
@@ -27,6 +27,7 @@
     <a v-if="business.website" :href="business.website" itemprop="url">{{
       business.website
     }}</a>
+    <img itemprop="image" :src="image" :alt="business.name" />
     <div
       itemprop="aggregateRating"
       itemscope
@@ -52,6 +53,10 @@ export default {
   computed: {
     business() {
       return this.id ? this.$store.getters['businesses/get'](this.id) : null
+    },
+    image() {
+      // We have to provide an image as it's mandatory.  Relative images are ok.
+      return require('~/static/share.png')
     },
   },
 }


### PR DESCRIPTION
This adds a component for the schema.org info and includes it from business.

This is a separate component for two reasons:
* It isolates all this stuff in one place, which I think is more maintainable than scattering the schema.org markup throughout.  That doesn't affect whether it gets parsed.
* When viewing the page for a single business, we only want to show markup for that selected business, even though the info about the others will appear visually on the page.  That's easier this way.

Tested using Google Rich Results tool.